### PR TITLE
fix(xlsx-to-json): pass cellDates:true to readFile options

### DIFF
--- a/src/utils/xlsx-to-json.ts
+++ b/src/utils/xlsx-to-json.ts
@@ -7,7 +7,7 @@ import { writeJSONFile } from "./filesystem";
 
 const fileDIR3ToJSON = async (input: string): Promise<string | undefined> => {
   try {
-    const workBook = XLSX.readFile(input);
+    const workBook = XLSX.readFile(input, { cellDates: true });
     if (workBook.SheetNames.length < 1) {
       throw new Error("XLSX file has no sheets");
     }


### PR DESCRIPTION
Fix #1. According to [https://docs.sheetjs.com/](https://docs.sheetjs.com/):

> XLSX also supports a special date type d where the data is an ISO 8601 date string. The formatter converts the date back to a number. The default behavior for all parsers is to generate number cells. Setting cellDates to true will force the generators to store dates.

So I pass cellDates: true and now I have a date with a valid ISO 8601 string. In any case I should be warned that I may have a problem with the local timezone:

>  Since JSON does not have a natural Date type, parsers are generally expected to store ISO 8601 Date strings like you would get from date.toISOString(). On the other hand, writers and exporters should be able to handle date strings and JS Date objects. Note that Excel disregards timezone modifiers and treats all dates in the local timezone. The library does not correct for this error.